### PR TITLE
support non root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ cd martin-starter
 docker compose up -d
 ```
 
-Then, you can access the app at http://localhost
+Then, you can access the app at http://localhost:8080/
 
-- catalog: `http://localhost/martin/catalog`
-- sprite: `http://localhost/martin/sprite/maki[.png|.json]`
+- catalog: `http://localhost:8080/martin/catalog`
+- sprite: `http://localhost:8080/martin/sprite/maki[.png|.json]`
 
 ## diagram
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     postgis:
         image: kartoza/postgis:15-3
@@ -7,7 +6,7 @@ services:
             - POSTGRES_PASS=docker
             - POSTGRES_DB=postgres
         ports:
-            - '5432:5432'
+            - 5432
         volumes:
             - postgis-data:/var/lib/postgresql
             - ./postgis-init/:/docker-entrypoint-initdb.d/
@@ -19,10 +18,10 @@ services:
             timeout: 5s
             retries: 5
     martin:
-        image: ghcr.io/maplibre/martin:v0.10.0
+        image: ghcr.io/maplibre/martin:v0.17.0
         restart: unless-stopped
         ports:
-            - 3000:3000
+            - 3000
         depends_on:
             postgis:
                 condition: service_healthy
@@ -34,7 +33,7 @@ services:
     nginx:
         image: nginx
         ports:
-            - '80:80'
+            - '8080:80'
         volumes:
             - ./nginx/html:/usr/share/nginx/html
             - ./nginx/conf.d:/etc/nginx/conf.d

--- a/nginx/html/index.html
+++ b/nginx/html/index.html
@@ -1,9 +1,9 @@
 <html lang="ja">
     <head>
         <title>Martin Tile Server</title>
-        <script src="https://unpkg.com/maplibre-gl@3.5.2/dist/maplibre-gl.js"></script>
+        <script src="https://unpkg.com/maplibre-gl@5.6.1/dist/maplibre-gl.js"></script>
         <link
-            href="https://unpkg.com/maplibre-gl@3.5.2/dist/maplibre-gl.css"
+            href="https://unpkg.com/maplibre-gl@5.6.1/dist/maplibre-gl.css"
             rel="stylesheet"
         />
     </head>
@@ -18,8 +18,8 @@
                 localIdeographFontFamily: false, // to load CJK fonts
                 style: {
                     version: 8,
-                    sprite: 'http://localhost/martin/sprite/maki',
-                    glyphs: 'http://localhost/martin/font/{fontstack}/{range}',
+                    sprite: 'http://localhost:8080/martin/sprite/maki',
+                    glyphs: 'http://localhost:8080/martin/font/{fontstack}/{range}',
                     sources: {
                         osm: {
                             type: 'raster',
@@ -31,21 +31,21 @@
                         martin_polygons: {
                             type: 'vector',
                             tiles: [
-                                'http://localhost/martin/polygons/{z}/{x}/{y}',
+                                'http://localhost:8080/martin/polygons/{z}/{x}/{y}',
                             ],
                             maxzoom: 14,
                         },
                         martin_points: {
                             type: 'vector',
                             tiles: [
-                                'http://localhost/martin/points/{z}/{x}/{y}',
+                                'http://localhost:8080/martin/points/{z}/{x}/{y}',
                             ],
                             maxzoom: 12,
                         },
                         martin_lines: {
                             type: 'vector',
                             tiles: [
-                                'http://localhost/martin/n06_22_highwaysection/{z}/{x}/{y}',
+                                'http://localhost:8080/martin/n06_22_highwaysection/{z}/{x}/{y}',
                             ],
                         },
                     },


### PR DESCRIPTION
- 80版ポートをlistenするとrootユーザが必要になるので、8080ポートにして一般ユーザ権限でも動かせるようにした。
- ついでにmartinとMaplibre GL JSをアップグレードした。
- docker-compose.ymlのversionは廃止予定なので削除。